### PR TITLE
Remove form-inline class from form. Fixes #58

### DIFF
--- a/app/views/records/_form.html.erb
+++ b/app/views/records/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for form, url: record_form_action_url(form), html: {class: 'form-inline editor'} do |f| %>
+<%= simple_form_for form, url: record_form_action_url(form), html: { class: 'editor' } do |f| %>
   <div id="descriptions_display">
 	<%= render 'records/form_header' %>
     <div class="well">


### PR DESCRIPTION
It is not an inline-form.
Formerly looked like this:
![screen shot 2015-01-12 at 7 51 55
pm](https://cloud.githubusercontent.com/assets/92044/5714881/a8b7f15c-9a94-11e4-8793-eab2f944c23d.png)

Now it looks like this:
![screen shot 2015-01-12 at 7 52 21
pm](https://cloud.githubusercontent.com/assets/92044/5714882/afbbc564-9a94-11e4-8f9e-49137aec82fc.png)