### PR TITLE
Rename build_text_field to build_field

### DIFF
--- a/app/inputs/multi_value_input.rb
+++ b/app/inputs/multi_value_input.rb
@@ -12,7 +12,7 @@ class MultiValueInput < SimpleForm::Inputs::CollectionInput
     collection.each_with_index do |value, index|
       markup << <<-HTML
         <li class="field-wrapper">
-          #{build_text_field(value, index)}
+          #{build_field(value, index)}
         </li>
       HTML
     end
@@ -28,7 +28,7 @@ class MultiValueInput < SimpleForm::Inputs::CollectionInput
     # Although the 'index' parameter is not used in this implementation it is useful in an
     # an overridden version of this method, especially when the field is a complex object and
     # the override defines nested fields.
-    def build_text_field(value, index)
+    def build_field(value, index)
       options = input_html_options.dup
 
       options[:value] = value

--- a/spec/inputs/multi_value_input_spec.rb
+++ b/spec/inputs/multi_value_input_spec.rb
@@ -44,7 +44,7 @@ describe 'MultiValueInput', type: :input do
     end
   end
 
-  describe '#build_text_field' do
+  describe '#build_field' do
     let(:foo) { Foo.new }
     before { foo.bar = ['bar1', 'bar2'] }
     let(:builder) { double("builder", object: foo, object_name: 'foo') }
@@ -52,9 +52,9 @@ describe 'MultiValueInput', type: :input do
     subject { MultiValueInput.new(builder, :bar, nil, :multi_value, {}) }
 
     it 'renders multi-value' do
-      expect(subject).to receive(:build_text_field).with('bar1', 0)
-      expect(subject).to receive(:build_text_field).with('bar2', 1)
-      expect(subject).to receive(:build_text_field).with('', 2)
+      expect(subject).to receive(:build_field).with('bar1', 0)
+      expect(subject).to receive(:build_field).with('bar2', 1)
+      expect(subject).to receive(:build_field).with('', 2)
       subject.input({})
     end
   end


### PR DESCRIPTION
In a subclass the field may not be text (e.g. select box)