### PR TITLE
Initialize required fields so an NPE is avoided in required?()

### DIFF
--- a/app/forms/hydra_editor/form.rb
+++ b/app/forms/hydra_editor/form.rb
@@ -7,7 +7,8 @@ module HydraEditor
     include Hydra::Presenter
     included do
       class_attribute :required_fields
-      delegate :errors, :to => :model
+      self.required_fields = []
+      delegate :errors, to: :model
     end
 
     def initialize(model)

--- a/spec/forms/hydra_editor_form_spec.rb
+++ b/spec/forms/hydra_editor_form_spec.rb
@@ -12,7 +12,6 @@ describe HydraEditor::Form do
       self.model_class = TestModel
       # Terms is the list of fields displayed by app/views/records/_form.html.erb
       self.terms = [:title, :creator]
-      self.required_fields = [:title]
     end
   end
 
@@ -75,10 +74,21 @@ describe HydraEditor::Form do
   end
 
   describe ".validators_on" do
-    it "should create them for required fields" do
-      expect(TestForm.validators_on(:title).first).to be_instance_of HydraEditor::Form::Validator
-      expect(TestForm.validators_on(:title).first.options).to eq({})
-      expect(TestForm.validators_on(:title).first.kind).to eq :presence
+    context "with required fields" do
+      before do
+        TestForm.required_fields = [:title]
+      end
+      it "should create them for required fields" do
+        expect(TestForm.validators_on(:title).first).to be_instance_of HydraEditor::Form::Validator
+        expect(TestForm.validators_on(:title).first.options).to eq({})
+        expect(TestForm.validators_on(:title).first.kind).to eq :presence
+      end
     end
+    context "without required fields" do
+      it "should create them for required fields" do
+        expect(TestForm.validators_on(:title)).to eq []
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This should fix the errors in sufia:

```
     ActionView::Template::Error:
       undefined method `include?' for nil:NilClass
     # ./app/views/records/edit_fields/_resource_type.html.erb:1:in `___sers_justin_workspace_sufia_app_views_records_edit_fields__resource_type_html_erb___4469442876656012746_70266896619520'
     # ./app/views/collections/_form.html.erb:6:in `block (2 levels) in ___sers_justin_workspace_sufia_app_views_collections__form_html_erb__2024584845455485257_70266875842440'
     # ./app/views/collections/_form.html.erb:5:in `each'
     # ./app/views/collections/_form.html.erb:5:in `block in ___sers_justin_workspace_sufia_app_views_collections__form_html_erb__2024584845455485257_70266875842440'
     # ./app/views/collections/_form.html.erb:1:in `___sers_justin_workspace_sufia_app_views_collections__form_html_erb__2024584845455485257_70266875842440'
```